### PR TITLE
Add --force-panel-type and --force-external-orientation arguments

### DIFF
--- a/src/drm.cpp
+++ b/src/drm.cpp
@@ -43,6 +43,7 @@ struct drm_t g_DRM = {};
 uint32_t g_nDRMFormat = DRM_FORMAT_INVALID;
 uint32_t g_nDRMFormatHDR = DRM_FORMAT_INVALID;
 bool g_bRotated = false;
+bool g_bDisplayTypeInternal = false;
 bool g_bUseLayers = true;
 bool g_bDebugLayers = false;
 const char *g_sOutputName = nullptr;
@@ -1638,7 +1639,7 @@ void drm_unlock_fbid( struct drm_t *drm, uint32_t fbid )
 static void update_drm_effective_orientation(struct drm_t *drm, struct connector *conn, const drmModeModeInfo *mode)
 {
 	drm_screen_type screenType = drm_get_screen_type(drm);
-	if ( screenType == DRM_SCREEN_TYPE_EXTERNAL )
+	if ( screenType == DRM_SCREEN_TYPE_EXTERNAL && g_bDisplayTypeInternal == true )
 	{
 			switch ( g_drmModeExternalOrientation )
 		{
@@ -1649,7 +1650,7 @@ static void update_drm_effective_orientation(struct drm_t *drm, struct connector
 				g_drmEffectiveOrientation = DRM_MODE_ROTATE_90;
 				break;
 			case PANEL_EXTERNAL_ORIENTATION_180:
-			g_drmEffectiveOrientation = DRM_MODE_ROTATE_180;
+				g_drmEffectiveOrientation = DRM_MODE_ROTATE_180;
 				break;
 			case PANEL_EXTERNAL_ORIENTATION_270:
 				g_drmEffectiveOrientation = DRM_MODE_ROTATE_270;
@@ -2573,6 +2574,10 @@ drm_screen_type drm_get_connector_type(drmModeConnector *connector)
 			return DRM_SCREEN_TYPE_INTERNAL;
 			break;
 		case PANEL_TYPE_EXTERNAL:
+			if (connector->connector_type == DRM_MODE_CONNECTOR_eDP ||
+					connector->connector_type == DRM_MODE_CONNECTOR_LVDS ||
+					connector->connector_type == DRM_MODE_CONNECTOR_DSI)
+					g_bDisplayTypeInternal = true;
 			return DRM_SCREEN_TYPE_EXTERNAL;
 			break;
 		case PANEL_TYPE_AUTO:

--- a/src/drm.cpp
+++ b/src/drm.cpp
@@ -2573,6 +2573,8 @@ bool drm_get_vrr_in_use(struct drm_t *drm)
 
 drm_screen_type drm_get_connector_type(drmModeConnector *connector)
 {
+	// Set to the default state of false to make sure the external display isn't rotated when a system is docked
+	g_bDisplayTypeInternal = false;
 	switch ( g_drmPanelType )
 	{
 		case PANEL_TYPE_INTERNAL:

--- a/src/drm.cpp
+++ b/src/drm.cpp
@@ -1661,6 +1661,11 @@ static void update_drm_effective_orientation(struct drm_t *drm, struct connector
 		}
 		return;
 	}
+	else if ( screenType == DRM_SCREEN_TYPE_EXTERNAL )
+	{
+		g_drmEffectiveOrientation = DRM_MODE_ROTATE_0;
+		return;
+	}
 
 	switch ( g_drmModeOrientation )
 	{

--- a/src/drm.hpp
+++ b/src/drm.hpp
@@ -291,8 +291,24 @@ enum g_panel_orientation {
 	PANEL_ORIENTATION_AUTO,
 };
 
+enum g_panel_external_orientation {
+	PANEL_EXTERNAL_ORIENTATION_0,	/* NORMAL */
+	PANEL_EXTERNAL_ORIENTATION_270,	/* RIGHT */
+	PANEL_EXTERNAL_ORIENTATION_90,	/* LEFT */
+	PANEL_EXTERNAL_ORIENTATION_180,	/* UPSIDE DOWN */
+	PANEL_EXTERNAL_ORIENTATION_AUTO,
+};
+
+enum g_panel_type {
+	PANEL_TYPE_INTERNAL,
+	PANEL_TYPE_EXTERNAL,
+	PANEL_TYPE_AUTO,
+};
+
 extern enum drm_mode_generation g_drmModeGeneration;
 extern enum g_panel_orientation g_drmModeOrientation;
+extern enum g_panel_external_orientation g_drmModeExternalOrientation;
+extern enum g_panel_type g_drmPanelType;
 
 extern std::atomic<uint64_t> g_drmEffectiveOrientation; // DRM_MODE_ROTATE_*
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -110,6 +110,8 @@ const struct option *gamescope_options = (struct option[]){
 	{ "disable-xres", no_argument, nullptr, 'x' },
 	{ "fade-out-duration", required_argument, nullptr, 0 },
 	{ "force-orientation", required_argument, nullptr, 0 },
+	{ "force-external-orientation", required_argument, nullptr, 0 },
+	{ "force-panel-type", required_argument, nullptr, 0 },
 	{ "force-windows-fullscreen", no_argument, nullptr, 0 },
 
 	{ "hdr-enabled", no_argument, nullptr, 0 },
@@ -151,6 +153,8 @@ const char usage[] =
 	"  --xwayland-count               create N xwayland servers\n"
 	"  --prefer-vk-device             prefer Vulkan device for compositing (ex: 1002:7300)\n"
 	"  --force-orientation            rotate the internal display (left, right, normal, upsidedown)\n"
+	"  --force-external-orientation   rotate the external display (left, right, normal, upsidedown)\n"
+	"  --force-panel-type             force gamescope to treat the display as either internal or external\n"
 	"  --force-windows-fullscreen     force windows inside of gamescope to be the size of the nested display (fullscreen)\n"
 	"  --cursor-scale-height		  if specified, sets a base output height to linearly scale the cursor against.\n"
 	"  --hdr-enabled                  enable HDR output (needs Gamescope WSI layer enabled for support from clients)\n"
@@ -315,6 +319,18 @@ static enum drm_mode_generation parse_drm_mode_generation(const char *str)
 	}
 }
 
+static enum g_panel_type force_panel_type(const char *str)
+{
+	if (strcmp(str, "internal") == 0) {
+		return PANEL_TYPE_INTERNAL;
+	} else if (strcmp(str, "external") == 0) {
+		return PANEL_TYPE_EXTERNAL;
+	} else {
+		fprintf( stderr, "gamescope: invalid value for --force-panel-type\n" );
+		exit(1);
+	}
+}
+
 static enum g_panel_orientation force_orientation(const char *str)
 {
 	if (strcmp(str, "normal") == 0) {
@@ -327,6 +343,22 @@ static enum g_panel_orientation force_orientation(const char *str)
 		return PANEL_ORIENTATION_180;
 	} else {
 		fprintf( stderr, "gamescope: invalid value for --force-orientation\n" );
+		exit(1);
+	}
+}
+
+static enum g_panel_external_orientation force_external_orientation(const char *str)
+{
+	if (strcmp(str, "normal") == 0) {
+		return PANEL_EXTERNAL_ORIENTATION_0;
+	} else if (strcmp(str, "right") == 0) {
+		return PANEL_EXTERNAL_ORIENTATION_270;
+	} else if (strcmp(str, "left") == 0) {
+		return PANEL_EXTERNAL_ORIENTATION_90;
+	} else if (strcmp(str, "upsidedown") == 0) {
+		return PANEL_EXTERNAL_ORIENTATION_180;
+	} else {
+		fprintf( stderr, "gamescope: invalid value for --force-external-orientation\n" );
 		exit(1);
 	}
 }
@@ -496,6 +528,10 @@ int main(int argc, char **argv)
 					g_drmModeGeneration = parse_drm_mode_generation( optarg );
 				} else if (strcmp(opt_name, "force-orientation") == 0) {
 					g_drmModeOrientation = force_orientation( optarg );
+				} else if (strcmp(opt_name, "force-external-orientation") == 0) {
+					g_drmModeExternalOrientation = force_external_orientation( optarg );
+				} else if (strcmp(opt_name, "force-panel-type") == 0) {
+					g_drmPanelType = force_panel_type( optarg );
 				} else if (strcmp(opt_name, "sharpness") == 0 ||
 						   strcmp(opt_name, "fsr-sharpness") == 0) {
 					g_upscaleFilterSharpness = atoi( optarg );


### PR DESCRIPTION
This allows us to force the internal display of a handheld to be treated either as an internal or external display and control the orientation of the display in this configuration. I'll be adding another PR later to give control of the rotation for external displays as well. i.e TV/Monitors for arcade setups.

- Potentially useful for devices such as the Aya Air Plus.
- Can be used to enable scaling options in steam.