### PR TITLE
Fix for crash on AYANEO geek

### DIFF
--- a/src/drm.cpp
+++ b/src/drm.cpp
@@ -524,6 +524,11 @@ const char *drm_get_patched_edid_path()
 
 static void create_patched_edid( const uint8_t *orig_data, size_t orig_size, drm_t *drm, struct connector *conn )
 {
+	// A zero length indicates that the edid parsing failed.
+	if (orig_size == 0) {
+		return;
+	}
+
 	std::vector<uint8_t> edid(orig_data, orig_data + orig_size);
 
 	if ( g_bRotated )


### PR DESCRIPTION
On certain configurations the EDID retrieval and parsing seems to fail, leading to create_patched_edid accessing out of bounds indexes on a zero length vector.

This fixes an issue on my AYANEO Geek with gamescope not launching with the following error:

```
/usr/include/c++/12.2.1/bits/stl_vector.h:1123: constexpr std::vector<_Tp, _Alloc>::reference std::vector<_Tp, _Alloc>::operator[](size_type) [with _Tp = unsigned char; _Alloc = std::allocator<unsigned char>; reference = unsigned char&; size_type = long unsigned int]: Assertion '__n < this->size()' failed.
```